### PR TITLE
'22 Q13, fixing solution

### DIFF
--- a/2022/day13/main.go
+++ b/2022/day13/main.go
@@ -46,7 +46,9 @@ func part1(input string) int {
 	goodIndexSum := 0
 	for i, pair := range pairs {
 		left, right := pair[0], pair[1]
-		if isInOrder(left, right) {
+        inOrder, isTied := isInOrder(left, right) 
+        if isTied { panic("Tied at the top level") }
+		if inOrder {
 			goodIndexSum += i + 1
 		}
 	}
@@ -69,7 +71,9 @@ func part2(input string) int {
 
 	sort.Slice(allPackets, func(i, j int) bool {
 		left, right := allPackets[i], allPackets[j]
-		return isInOrder(left, right)
+        inOrder, isTied := isInOrder(left, right) 
+        if isTied { panic("Tied at the top level") }
+		return inOrder
 	})
 
 	ans := 1
@@ -100,10 +104,10 @@ func parseRawString(raw string) []interface{} {
 	return ans
 }
 
-func isInOrder(left, right []interface{}) bool {
+func isInOrder(left, right []interface{}) (inOrder bool, isTied bool) {
 	for l := 0; l < len(left); l++ {
 		if l > len(right)-1 {
-			return false
+			return false, false
 		}
 
 		// attempt to convert both to ints...
@@ -114,7 +118,7 @@ func isInOrder(left, right []interface{}) bool {
 		rightList, isRightList := right[l].([]interface{})
 		if isLeftNum && isRightNum {
 			if leftNum != rightNum {
-				return leftNum < rightNum
+				return leftNum < rightNum, false
 			}
 		} else if isLeftNum || isRightNum {
 			if isLeftNum {
@@ -125,15 +129,21 @@ func isInOrder(left, right []interface{}) bool {
 				panic(fmt.Sprintf("expected one num %T:%v, %T:%v", left[l],
 					left[l], right[l], right[l]))
 			}
-			return isInOrder(leftList, rightList)
+            inOrder, isTied := isInOrder(leftList, rightList)
+            if !isTied { return inOrder, isTied }
 		} else {
 			// both lists
 			if !isLeftList || !isRightList {
 				panic(fmt.Sprintf("expected two lists %T:%v, %T:%v", left[l],
 					left[l], right[l], right[l]))
 			}
-			return isInOrder(leftList, rightList)
+            inOrder, isTied := isInOrder(leftList, rightList)
+            if !isTied { return inOrder, isTied }
 		}
 	}
-	return true
+    if len(left) == len(right) {
+        return false, true
+    }
+
+	return true, false
 }


### PR DESCRIPTION
Really useful repo! Got stuck on AoC '22 #13, and the solution from this repo was not accepted (6,104). Maybe I set up the repo incorrectly, but I documented what I see the problem is and my solution to it below. 

**The problem:** `isInOrder(left, right)` returns ties incorrectly as inOrder, while it should just continue to evaluate unless it's the end of the input. For example, take the two example inputs:

#1
[[1,2,3,4], 5]
[[1,2,3,4], 3]

#2
[[1,2,3,4], 2]
[[1,2,3,4], 3]

#1 is NOT in order, #2 is in order. However, `isInOrder` returns that BOTH are in order. `isInOrder` evaluates the first first element of both lists, sees they are lists. Then it recurses on the list, checking each element. After checking all elements and finding all ties, it returns true (line 138) and pops the recursion. Then line 128/135 return as true, while they should really continue checking the rest of the list since the recursed list was tied. 

My Solution: add a tied-indicator to `isInOrder`.

I modify `isInOrder` to return two booleans, one to indicate if they are in order, the other to indicate if there is a tie. The recursive calls will now only return if an explicitly correct/incorrect ordering was found. If a tie was found, `isInOrder` continues to the next element. `isInOrder` only returns a tied indicator if it iterates through the whole list without finding an out of order pair and if the list lengths are equal. This returns the correct solution (5,675).



